### PR TITLE
Enable Covid 19 cases as a selectable category and fix population estimates

### DIFF
--- a/src/main/java/com/projectrefocus/service/categories/entity/CovidCasesEntity.java
+++ b/src/main/java/com/projectrefocus/service/categories/entity/CovidCasesEntity.java
@@ -1,0 +1,61 @@
+package com.projectrefocus.service.categories.entity;
+
+import com.projectrefocus.service.calendar.entity.CalendarDateEntity;
+import com.projectrefocus.service.geography.entity.StateEntity;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+@Entity
+@Table(name = "state_cases")
+public class CovidCasesEntity {
+
+    @Id
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "cases")
+    private Integer cases;
+
+    @Fetch(FetchMode.JOIN)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "calendar_date_id")
+    private CalendarDateEntity date;
+
+    @Fetch(FetchMode.JOIN)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "state_id")
+    private StateEntity state;
+
+    public int getId() {
+        return this.id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Integer getCases() {
+        return this.cases;
+    }
+
+    public void setCases(Integer cases) {
+        this.cases = cases;
+    }
+
+    public CalendarDateEntity getDate() {
+        return this.date;
+    }
+
+    public void setDate(CalendarDateEntity date) {
+        this.date = date;
+    }
+
+    public StateEntity getState() {
+        return state;
+    }
+
+    public void setState(StateEntity state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/com/projectrefocus/service/categories/entity/PopulationEstimateEntity.java
+++ b/src/main/java/com/projectrefocus/service/categories/entity/PopulationEstimateEntity.java
@@ -1,0 +1,47 @@
+package com.projectrefocus.service.categories.entity;
+
+import com.projectrefocus.service.geography.entity.StateEntity;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+@Entity
+@Table(name = "state_population_2020")
+public class PopulationEstimateEntity {
+
+    @Id
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "population")
+    private Integer population;
+
+    @Fetch(FetchMode.JOIN)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "state_id")
+    private StateEntity state;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getPopulation() {
+        return population;
+    }
+
+    public void setPopulation(Integer population) {
+        this.population = population;
+    }
+
+    public StateEntity getState() {
+        return state;
+    }
+
+    public void setState(StateEntity state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/com/projectrefocus/service/categories/repository/CovidCasesRepository.java
+++ b/src/main/java/com/projectrefocus/service/categories/repository/CovidCasesRepository.java
@@ -1,0 +1,14 @@
+package com.projectrefocus.service.categories.repository;
+
+import com.projectrefocus.service.categories.entity.CovidCasesEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CovidCasesRepository extends JpaRepository<CovidCasesEntity, Integer> {
+    @Query(
+            "SELECT CAST(COALESCE(COUNT(cce.id), 0) AS integer) FROM CovidCasesEntity cce " +
+            "INNER JOIN FETCH StateEntity se ON se.id = cce.state.id " +
+            "WHERE se.id = :stateId"
+    )
+    Integer doesCategoryIncludeState(Byte stateId);
+}

--- a/src/main/java/com/projectrefocus/service/categories/repository/EmploymentStatusRepository.java
+++ b/src/main/java/com/projectrefocus/service/categories/repository/EmploymentStatusRepository.java
@@ -15,5 +15,5 @@ public interface EmploymentStatusRepository extends JpaRepository<EmploymentStat
             "INNER JOIN FETCH StateEntity se ON se.id = ce.state.id " +
             "WHERE se.id = :stateId"
     )
-    Integer doesCategoryIncludeStates(Byte stateId);
+    Integer doesCategoryIncludeState(Byte stateId);
 }

--- a/src/main/java/com/projectrefocus/service/categories/repository/MotorVehicleCollisionRepository.java
+++ b/src/main/java/com/projectrefocus/service/categories/repository/MotorVehicleCollisionRepository.java
@@ -15,5 +15,5 @@ public interface MotorVehicleCollisionRepository extends JpaRepository<MotorVehi
           "INNER JOIN StateEntity se ON se.id = zecc.state.id " +
           "WHERE se.id = :stateId"
     )
-    Integer doesCategoryIncludeStates(Byte stateId);
+    Integer doesCategoryIncludeState(Byte stateId);
 }

--- a/src/main/java/com/projectrefocus/service/categories/repository/PopulationEstimateRepository.java
+++ b/src/main/java/com/projectrefocus/service/categories/repository/PopulationEstimateRepository.java
@@ -1,0 +1,14 @@
+package com.projectrefocus.service.categories.repository;
+
+import com.projectrefocus.service.categories.entity.PopulationEstimateEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PopulationEstimateRepository extends JpaRepository<PopulationEstimateEntity, Integer> {
+    @Query(
+            "SELECT CAST(COALESCE(COUNT(pee.id), 0) AS integer) FROM PopulationEstimateEntity pee " +
+            "INNER JOIN FETCH StateEntity se ON se.id = pee.state.id " +
+            "WHERE se.id = :stateId"
+    )
+    Integer doesCategoryIncludeState(Byte stateId);
+}

--- a/src/main/java/com/projectrefocus/service/categories/repository/SupplementalNutritionAssistanceProgramRepository.java
+++ b/src/main/java/com/projectrefocus/service/categories/repository/SupplementalNutritionAssistanceProgramRepository.java
@@ -13,5 +13,5 @@ public interface SupplementalNutritionAssistanceProgramRepository extends JpaRep
             "INNER JOIN FETCH StateEntity se ON se.id = ce.state.id " +
             "WHERE se.id = :stateId"
     )
-    Integer doesCategoryIncludeStates(Byte stateId);
+    Integer doesCategoryIncludeState(Byte stateId);
 }

--- a/src/main/java/com/projectrefocus/service/categories/service/CategoryServiceImpl.java
+++ b/src/main/java/com/projectrefocus/service/categories/service/CategoryServiceImpl.java
@@ -1,9 +1,7 @@
 package com.projectrefocus.service.categories.service;
 
 import com.projectrefocus.service.categories.dto.CategoryDto;
-import com.projectrefocus.service.categories.repository.EmploymentStatusRepository;
-import com.projectrefocus.service.categories.repository.MotorVehicleCollisionRepository;
-import com.projectrefocus.service.categories.repository.SupplementalNutritionAssistanceProgramRepository;
+import com.projectrefocus.service.categories.repository.*;
 import com.projectrefocus.service.dundas.dto.DashboardFileObject;
 import com.projectrefocus.service.dundas.service.DundasFileService;
 import org.springframework.stereotype.Service;
@@ -16,17 +14,22 @@ import java.util.Set;
 public class CategoryServiceImpl implements CategoryService {
 
     private final DundasFileService dundasFileService;
+    private final CovidCasesRepository covidCasesRepository;
     private final EmploymentStatusRepository employmentStatusRepository;
     private final MotorVehicleCollisionRepository motorVehicleCollisionRepository;
+    private final PopulationEstimateRepository populationEstimateRepository;
     private final SupplementalNutritionAssistanceProgramRepository supplementalNutritionAssistanceProgramRepository;
 
     public CategoryServiceImpl(
             DundasFileService dundasFileService, EmploymentStatusRepository employmentStatusRepository,
-            MotorVehicleCollisionRepository motorVehicleCollisionRepository, SupplementalNutritionAssistanceProgramRepository supplementalNutritionAssistanceProgramRepository
+            MotorVehicleCollisionRepository motorVehicleCollisionRepository, SupplementalNutritionAssistanceProgramRepository supplementalNutritionAssistanceProgramRepository,
+            PopulationEstimateRepository populationEstimateRepository, CovidCasesRepository covidCasesRepository
     ) {
         this.dundasFileService = dundasFileService;
+        this.covidCasesRepository = covidCasesRepository;
         this.employmentStatusRepository = employmentStatusRepository;
         this.motorVehicleCollisionRepository = motorVehicleCollisionRepository;
+        this.populationEstimateRepository = populationEstimateRepository;
         this.supplementalNutritionAssistanceProgramRepository = supplementalNutritionAssistanceProgramRepository;
     }
 
@@ -46,14 +49,20 @@ public class CategoryServiceImpl implements CategoryService {
     public List<CategoryDto> getCategoriesByStates(List<Byte> stateIds) {
         List<CategoryDto> allCategories = getAllCategories();
         Set<String> categories = new HashSet<>();
-        if (stateIds.stream().allMatch(id -> employmentStatusRepository.doesCategoryIncludeStates(id) != 0)) {
+        if (stateIds.stream().allMatch(id -> employmentStatusRepository.doesCategoryIncludeState(id) != 0)) {
             categories.add("Employment Status");
         }
-        if (stateIds.stream().allMatch(id -> motorVehicleCollisionRepository.doesCategoryIncludeStates(id) != 0)) {
+        if (stateIds.stream().allMatch(id -> motorVehicleCollisionRepository.doesCategoryIncludeState(id) != 0)) {
             categories.add("Motor Vehicle Collision");
         }
-        if (stateIds.stream().allMatch(id -> supplementalNutritionAssistanceProgramRepository.doesCategoryIncludeStates(id) != 0)) {
+        if (stateIds.stream().allMatch(id -> supplementalNutritionAssistanceProgramRepository.doesCategoryIncludeState(id) != 0)) {
             categories.add("Supplemental Nutrition Assistance Program");
+        }
+        if (stateIds.stream().allMatch(id -> populationEstimateRepository.doesCategoryIncludeState(id) != 0)) {
+            categories.add("Population Estimates");
+        }
+        if (stateIds.stream().allMatch(id -> covidCasesRepository.doesCategoryIncludeState(id) != 0)) {
+            categories.add("Covid 19 Cases");
         }
         return allCategories.stream().filter(category -> categories.contains(category.getName())).toList();
     }


### PR DESCRIPTION
This PR re enables Covid 19 Cases as a selectable category and also fixes population estimates to appear as an available category for selection when multiple states are selected.

*Note* 
To return the proper hierarchy members when calling the `/geography` endpoint with the Covid 19 Cases category you need to specify the `State` value for the `geographyType`

Ex:
`http://projectrefocus.gscbinc.com/dashboard-service/geography?categoryId={categoryId}&geographyType=State`